### PR TITLE
Versions: [runtime|1.7.0-next.3] [types|1.9.0-next.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 | Version | Type |
 | ------- | ---- |
-| [1.7.0-next.2](https://www.npmjs.com/package/melon-runtime/v/1.7.0-next.2) | Last development |
+| [1.7.0-next.3](https://www.npmjs.com/package/melon-runtime/v/1.7.0-next.3) | Last development |
 | [1.6.0](https://www.npmjs.com/package/melon-runtime/v/1.6.0) | **Last Stable** |
 
 ## Generating and executing a project
@@ -56,6 +56,17 @@
 ## Extra
 
 - [Check the MelonRuntime-compatible verified useful NPM packages](https://github.com/MelonRuntime/MelonRuntime/blob/main/compatible-libraries.md)
+
+## Contributors 
+
+| [Victória Rose](https://github.com/EternalQuasar0206) |
+| -------------- |
+| <div align="center"><img src="https://avatars.githubusercontent.com/u/70824102?v=4" width="60"></div> |
+
+| [Gabriel Grubba](https://github.com/Grubba27) |
+| -------------- |
+| <div align="center"><img src="https://avatars.githubusercontent.com/u/70247653?v=4" width="60"></div> |
+
 
 ## Sponsors 
 

--- a/projects/melon-runtime/MelonJS/StaticData.cs
+++ b/projects/melon-runtime/MelonJS/StaticData.cs
@@ -6,7 +6,7 @@ namespace MelonJS
     {
         public static string ApplicationInfo()
         {
-            return $"MelonRuntime v{Assembly.GetExecutingAssembly().GetName().Version} [next.2]";
+            return $"MelonRuntime v{Assembly.GetExecutingAssembly().GetName().Version} [next.3]";
         }
     }
 }

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/environment.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/environment.js
@@ -3,7 +3,7 @@
         return __environment__.GetEnvironmentVariables()[name] ?? __environment_vars__[name]
     },
     getVariables: () => {
-        return Object.assign(__environment__.GetEnvironmentVariables()[name], __environment_vars__)
+        return Object.assign(__environment__.GetEnvironmentVariables(), __environment_vars__)
     },
     setVariable: (name, content) => {
         __environment_vars__.Add(name, content)

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/load.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/load.js
@@ -20,7 +20,7 @@
             content = content.join("")
         }
 
-        content = content.replaceAll("{funcArrow}", "=>").replaceAll("", "")
+        content = content.replaceAll("{funcArrow}", "=>")
 
         let parsedContent
 

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/std.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Tools/std.js
@@ -23,24 +23,6 @@
         return internal
     },
     /*
-     * std.reflect(targetNameAsString)
-     * The reflect function is a sugar that promotes a direct reflection to a value denoted 
-     * by its name in the form of a string inside the global code, this method should not be 
-     * specific actively used as it may not work in cases like complex objects
-     * */
-    reflect: (target) => {
-        if (enableDetailedInformation) {
-            debug.log
-                ("[Debug] This method should not be actively used as it may not work in specific cases like complex objects")
-        }
-
-        this.name = target
-        this.modificator = x => x
-        this.getValue = () => this.modificator(eval(`${this.name}`))
-
-        return this
-    },
-    /*
      * std.system.*
      * The reflect function is a sugar that promotes a direct reflection to a value denoted
      * by its name in the form of a string inside the global code, this method should not be

--- a/projects/melon-runtime/package.json
+++ b/projects/melon-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melon-runtime",
-  "version": "1.7.0-next.2",
+  "version": "1.7.0-next.3",
   "description": "MelonJS",
   "type": "module",
   "keywords": [

--- a/projects/melon-types/lib/types/Tools/std.d.ts
+++ b/projects/melon-types/lib/types/Tools/std.d.ts
@@ -6,11 +6,6 @@ type MWorker = {
 
 type Std = {
     shift: (value: any) => any,
-    reflect: (target: any) => {
-        name: string,
-        modificator: Function,
-        getValue: () => any,
-    },
     system: {
         getBaseFolder: () => string
     },

--- a/projects/melon-types/package.json
+++ b/projects/melon-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "melon-types",
-  "version": "1.9.0-next.1",
-  "description": "Typescript types for melon-runtime 1.7.0-next.2+",
+  "version": "1.9.0-next.2",
+  "description": "Typescript types for melon-runtime 1.7.0-next.3+",
   "types": "./lib/types/main.d.ts",
   "type": "module",
   "repository": {


### PR DESCRIPTION
fix: removed Replacement of a substring with itself in `load`
fix: remove Prototype-polluting assignment in `environment.getVariables`
fix: removed insecure `std.reflect` from internal library and types