### PR TITLE
Add separate typings for Melon's console

### DIFF
--- a/projects/melon-runtime/MelonJS/Properties/Resources.resx
+++ b/projects/melon-runtime/MelonJS/Properties/Resources.resx
@@ -302,7 +302,7 @@ babel/
       "types": [
         "melon-types"
       ],
-      "lib": [ "es2015" ]
+      "lib": [ "es2022" ]
     }
 }</value>
   </data>

--- a/projects/melon-runtime/MelonJS/Properties/Resources.resx
+++ b/projects/melon-runtime/MelonJS/Properties/Resources.resx
@@ -302,7 +302,7 @@ babel/
       "types": [
         "melon-types"
       ],
-      "lib": [ "es2015", "DOM" ]
+      "lib": [ "es2015" ]
     }
 }</value>
   </data>

--- a/projects/melon-types/lib/types/Tools/console.d.ts
+++ b/projects/melon-types/lib/types/Tools/console.d.ts
@@ -3,7 +3,7 @@ type MConsole = {
     error(...data: any[]): void,
     warn(...data: any[]): void,
     clear(): void,
-    read(): void,
+    read(): string,
     table(tabularData?: any, properties?: string[]): void
 }
 

--- a/projects/melon-types/lib/types/Tools/console.d.ts
+++ b/projects/melon-types/lib/types/Tools/console.d.ts
@@ -1,0 +1,10 @@
+type MConsole = {
+    group(...data: any[]): void;
+    error(...data: any[]): void;
+    warn(...data: any[]): void;
+    clear(): void;
+    read(): void;
+    table(tabularData?: any, properties?: string[]): void;
+}
+
+declare const console: MConsole

--- a/projects/melon-types/lib/types/Tools/console.d.ts
+++ b/projects/melon-types/lib/types/Tools/console.d.ts
@@ -1,5 +1,5 @@
 type MConsole = {
-    group(...data: any[]): void,
+    log(...data: any): void,
     error(...data: any[]): void,
     warn(...data: any[]): void,
     clear(): void,

--- a/projects/melon-types/lib/types/Tools/console.d.ts
+++ b/projects/melon-types/lib/types/Tools/console.d.ts
@@ -1,10 +1,10 @@
 type MConsole = {
-    group(...data: any[]): void;
-    error(...data: any[]): void;
-    warn(...data: any[]): void;
-    clear(): void;
-    read(): void;
-    table(tabularData?: any, properties?: string[]): void;
+    group(...data: any[]): void,
+    error(...data: any[]): void,
+    warn(...data: any[]): void,
+    clear(): void,
+    read(): void,
+    table(tabularData?: any, properties?: string[]): void
 }
 
 declare const console: MConsole


### PR DESCRIPTION
Fixes #112.

Melon doesn't have the same typings as the original DOM, so we're sticking to Melon's,

Not a fan of all the `any`s, but even the [DOM console typings](https://github.com/microsoft/TypeScript/blob/c6ff5f3b52d45842e5e56caf124cf5f5521c92ff/src/lib/dom.generated.d.ts#L17062) have them.