### PR TITLE
Rework: Enumerable<T> and type declarations

### DIFF
--- a/projects/melon-runtime/MelonJS/Program.cs
+++ b/projects/melon-runtime/MelonJS/Program.cs
@@ -5,7 +5,6 @@ using MelonJs.JavaScript.Containers;
 using MelonJs.Static.Jint;
 using MelonJS.Commands;
 using System.Reflection;
-using Jint;
 
 /* Generates a new JintContainer and a new Jint engine for execution - no arguments */
 JintStatic.CurrentJintEngine = new();

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -14,12 +14,12 @@
 
     /* Setup array-based structure */
     if (Array.isArray(base)) {
-        base.forEach(x => this.push(x));
+        base.forEach(x => this.add(x));
     }
     else if (Boolean(Number(base))) {
         let index = Number(base);
         while (index > 0) {
-            this.push(empty);
+            this.add(empty);
             index--;
         }
     }

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -1,7 +1,12 @@
-﻿function Enumerable(base = []) {
+﻿function Enumerable(base = [], capacity = -1) {
     this.count = 0;
+    this._errorCapacity = "Error: Exceeded limit capacity for this Enumerable";
     /* Define add */
     this.add = (value, index = 0) => {
+        if(capacity != -1 && base.length + 1 > capacity) {
+            throw new Error(this._errorCapacity);
+        }
+
         if (!this[index] && typeof this[index] !== "boolean") {
             this[index] = value;
             this.count++;
@@ -14,6 +19,10 @@
 
     /* Setup array-based structure */
     if (Array.isArray(base)) {
+        if(capacity != -1 && base.length > capacity) {
+            throw new Error(this._errorCapacity);
+        }
+
         base.forEach(x => this.add(x));
     }
     else if (Boolean(Number(base))) {

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -14,10 +14,10 @@
 
     /* Setup array-based structure */
     if (Array.isArray(base)) {
-        arg.forEach(x => this.push(x));
+        base.forEach(x => this.push(x));
     }
-    else if (Boolean(Number(arg))) {
-        let index = Number(arg);
+    else if (Boolean(Number(base))) {
+        let index = Number(base);
         while (index > 0) {
             this.push(empty);
             index--;

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -39,31 +39,29 @@
 
         return result;
     }
-}
 
-function Enumerable(base) {
-    this._elements = Array.isArray(base) && arguments < 2 ? base : [...arguments]
-    this.elements = () => this._elements
-
-    this.where = (filter) => new Enumerable(this._elements).filter(filter)
-    this.top = (quantity) => new Enumerable(this._elements.slice(0, quantity))
-    this.bottom = (quantity) => new Enumerable(this._elements.reverse()).top(quantity)
-    this.first = () => this._elements[0]
-    this.last = () => new Enumerable(_elements.reverse()).first()
-    this.average = () => this._elements.reduce((partialSum, a) => partialSum + a) / this._elements.length
-    this.any = () => this._elements.length > 0
-    this.cast = (constructor) => new Enumerable(this._elements.map(x => new constructor(x)))
-
-    this.all = (condition = x => x === x) => {
-        const boolArray = this._elements.map(x => condition(x))
-        return boolArray.every(true)
+    /* Setup methods */
+    this.take = (quantity) => new Enumerable(this.toArray().slice(0, quantity));
+    this.skip = (quantity) => new Enumerable(this.toArray().slice(quantity, 0));
+    this.where = (filter) => new Enumerable(this.toArray()).filter(filter);
+    this.firstOrDefault = () => this[0] ?? null;
+    this.lastOrDefault = () => this[this.count - 1] ?? null;
+    this.first = () => this[0];
+    this.last = () => this[this.count - 1];
+    this.any = () => this.toArray().length > 0;
+    this.all = (condition = x => x === x) => this.toArray().map(x => condition(x)).every(true);
+    this.average = () => this.toArray().reduce((partialSum, a) => partialSum + a) / this._elements.length;
+    this.cast = (constructor) => new Enumerable(this.toArray().map(x => new constructor(x)));
+    this.equals = (element) => data.compare(this.toArray(), element);
+    this.addRange = (elements) => elements.forEach(this.add);
+    this.clear = () => {
+        let index = this.count;
+        while(index > 0) {
+            this[index - 1] = undefined;
+            index--;
+        }
     }
 
-    this.add = (element) => this._elements.add(element)
-    this.addRange = (elements) => Array.isArray(elements) ? this._elements = [this._elements, ...elements] : {}
-    this.lookFor = (element) => recursive.find(element, this._elements)
-    this.compare = (element, compFn = (a, b) => a === b) => recursive.compare(this._elements, element, compFn)
-    this.equals = (element) => this.compare(this._elements, element)
-
+    /* Return instance */
     return this;
 }

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -1,4 +1,47 @@
-﻿function Enumerable(base) {
+﻿function Enumerable(base = []) {
+    this.count = 0;
+    /* Define add */
+    this.add = (value, index = 0) => {
+        if (!this[index] && typeof this[index] !== "boolean") {
+            this[index] = value;
+            this.count++;
+            return;
+        }
+
+        index++;
+        this.add(value, index)
+    }
+
+    /* Setup array-based structure */
+    if (Array.isArray(base)) {
+        arg.forEach(x => this.push(x));
+    }
+    else if (Boolean(Number(arg))) {
+        let index = Number(arg);
+        while (index > 0) {
+            this.push(empty);
+            index--;
+        }
+    }
+
+    /* Define toArray */
+    this.toArray = () => {
+        let index = 0;
+        const result = [];
+
+        while (index < this.length) {
+            if (this[index] || typeof this[index] === "boolean") {
+                result.push(this[index]);
+            }
+
+            index++;
+        }
+
+        return result;
+    }
+}
+
+function Enumerable(base) {
     this._elements = Array.isArray(base) && arguments < 2 ? base : [...arguments]
     this.elements = () => this._elements
 

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -29,7 +29,7 @@
         let index = 0;
         const result = [];
 
-        while (index < this.length) {
+        while (index < this.count) {
             if (this[index] || typeof this[index] === "boolean") {
                 result.push(this[index]);
             }

--- a/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
+++ b/projects/melon-runtime/MelonJs.JavaScript/Bindings/Constructors/Enumerable.js
@@ -3,7 +3,7 @@
     this._errorCapacity = "Error: Exceeded limit capacity for this Enumerable";
     /* Define add */
     this.add = (value, index = 0) => {
-        if(capacity != -1 && base.length + 1 > capacity) {
+        if(capacity != -1 && this.count + 1 > capacity) {
             throw new Error(this._errorCapacity);
         }
 
@@ -19,10 +19,6 @@
 
     /* Setup array-based structure */
     if (Array.isArray(base)) {
-        if(capacity != -1 && base.length > capacity) {
-            throw new Error(this._errorCapacity);
-        }
-
         base.forEach(x => this.add(x));
     }
     else if (Boolean(Number(base))) {

--- a/projects/melon-types/lib/types/Constructors/Enumerable.d.ts
+++ b/projects/melon-types/lib/types/Constructors/Enumerable.d.ts
@@ -1,19 +1,21 @@
-declare interface Enumerable<T> extends Iterable<T> {
-    elements: () => T[],
-    where: (filter: (this: T) => boolean) => Enumerable<T> ,
-    top: (quantity: number) => Enumerable<T> ,
-    bottom: (quantity: number) => Enumerable<T>,
-    first: () => T,
-    last: () => T,
-    average: () => T,
-    any: () => boolean,
-    cast: (constructor: any) => Enumerable<any>,
-    all: (condition: (this: T) => boolean) => boolean,
-    add: (item: T) => void,
-    addRange: (items: Iterable<T>) => void,
-    lookFor: (element: T) => any,
-    compare: (element: T, compFn: (this: T) => boolean) => boolean,
-    equals: (target: any) => boolean
+declare class Enumerable<T> extends Array<T> {
+    constructor(args: Iterable<T>, capacity?: number);
+    count: number;
+    toArray: () => T[];
+    toEnumerable: () => T[];
+    take: (quantity: number) => Enumerable<T>;
+    skip: (quantity: number) => Enumerable<T>;
+    where: (filter: (target: T) => boolean) => Enumerable<T>;
+    firstOrDefault: () => T | null;
+    lastOrDefault: () => T | null;
+    first: () => T;
+    last: () => T;
+    any: () => boolean;
+    all: (condition: (target: T) => boolean) => boolean;
+    average: () => T;
+    cast: <T>(constructor: any) => Enumerable<T>;
+    equals: (target: any) => boolean;
+    add: (item: T) => void;
+    addRange: (items: Iterable<T>) => void;
+    clear: () => void;
 }
-
-declare function Enumerable<T>(args: Iterable<T>): void

--- a/projects/melon-types/lib/types/Constructors/Enumerable.d.ts
+++ b/projects/melon-types/lib/types/Constructors/Enumerable.d.ts
@@ -2,7 +2,6 @@ declare class Enumerable<T> extends Array<T> {
     constructor(args: Iterable<T>, capacity?: number);
     count: number;
     toArray: () => T[];
-    toEnumerable: () => T[];
     take: (quantity: number) => Enumerable<T>;
     skip: (quantity: number) => Enumerable<T>;
     where: (filter: (target: T) => boolean) => Enumerable<T>;


### PR DESCRIPTION
- Implemented a new rework of `Enumerable<T>` completely based on C# `Enumberable<T>` class with the methods and fields:
```ts
count: number
toArray: () => T[]
take: (quantity: number) => Enumerable<T>
skip: (quantity: number) => Enumerable<T>
where: (filter: (target: T) => boolean) => Enumerable<T>
firstOrDefault: () => T | null
lastOrDefault: () => T | null
first: () => T
last: () => T
any: () => boolean
all: (condition: (target: T) => boolean) => boolean
average: () => T
cast: <T>(constructor: any) => Enumerable<T>
equals: (target: any) => boolean
add: (item: T) => void
addRange: (items: Iterable<T>) => void
clear: () => void
```