### PR TITLE
fix: Invoke the correct overload for static methods

### DIFF
--- a/projects/melon-runtime/Melon.Library/Static/InteropReflection/ReflectionHelper.cs
+++ b/projects/melon-runtime/Melon.Library/Static/InteropReflection/ReflectionHelper.cs
@@ -31,16 +31,16 @@ namespace Melon.Library.Static.InteropReflection
                 types = _cachedMethodSearchTypes.Item2;
             }
 
-            IQueryable<MethodInfo> methods =
+            return
                 types
                 .First()
-                .GetMethods()
-                .Where(x => x.Name == methodName)
-                .AsQueryable();
-
-            var result = methods.ToList()[index];
-
-            return result?.Invoke(null, parameters.ToArray());
+                .InvokeMember(
+                    methodName,
+                    BindingFlags.InvokeMethod, 
+                    Type.DefaultBinder,
+                    null,
+                    parameters.ToArray()
+                );
         }
         public static dynamic? GetStaticProperty(string nSpace, string search, string fieldName)
         {


### PR DESCRIPTION
Static methods were always bound to its first overload, which is troublesome:

![image](https://user-images.githubusercontent.com/29522926/181662032-4cb45545-91fe-4d43-83d7-9c64ecc4c5ba.png)

This fix makes the reflection helper pick the correct overload according to the passed parameters.

![image](https://user-images.githubusercontent.com/29522926/181662092-6f623ed3-88cd-40c6-a799-6623513bc2fa.png)
