### PR TITLE
Revamp package.json scripts in melon-runtime

### DIFF
--- a/projects/melon-core/package.json
+++ b/projects/melon-core/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "compile": "babel --extensions .ts ./src/ --out-dir ./babel && webpack ./babel/index.js --config webpack.config.js"
+        "build": "babel --extensions .ts ./src/ --out-dir ./babel && webpack ./babel/index.js --config webpack.config.js"
     },
     "devDependencies": {
         "@babel/cli": "latest",

--- a/projects/melon-runtime/package.json
+++ b/projects/melon-runtime/package.json
@@ -4,9 +4,11 @@
   "description": "Declarative modern .NET JavaScript runtime",
   "type": "module",
   "scripts": {
-      "prepublish": "dotnet publish Melon -o Output",
-      "go": "dotnet exec Output/Melon.dll",
-      "dev": "dotnet publish Melon -o Output && dotnet exec Output/Melon.dll"
+    "build": "dotnet publish Melon -o Output",
+    "exec": "dotnet exec Output/Melon.dll",
+    "dev": "dotnet watch --no-hot-reload --project Melon",
+    "core": "cd ../melon-core && npm run build && cd ../melon-runtime && cp ../melon-core/dist/core.js ./Melon.Library/Bundle/core.js",
+    "prepublish": "npm run build"
   },
   "keywords": [
     "runtime",


### PR DESCRIPTION
### melon-core
- Rename `compile` to `build`, for consistency

### melon-runtime
- Modify `dev` command to use `dotnet watch`
- Rename `go` to `exec` so it's not confused with `dev`
- Add `core` command that builds `melon-core`, for ease of use
- Reuse `build` in `prepublish`